### PR TITLE
Ensure $? is not nil

### DIFF
--- a/Ruby/lib/terminal-notifier.rb
+++ b/Ruby/lib/terminal-notifier.rb
@@ -50,7 +50,7 @@ module TerminalNotifier
   # Raises if not supported on the current platform.
   def notify(message, options = {}, verbose = false)
     TerminalNotifier.execute(verbose, options.merge(:message => message))
-    $?.success?
+    $? && $?.success?
   end
   module_function :notify
 
@@ -60,7 +60,7 @@ module TerminalNotifier
   # If no ‘group’ ID is given, all notifications are removed.
   def remove(group = 'ALL', verbose = false)
     TerminalNotifier.execute(verbose, :remove => group)
-    $?.success?
+    $? && $?.success?
   end
   module_function :remove
 


### PR DESCRIPTION
Hi,

I got an error on CircleCI like this.
Its parallelism was 2x.

```
bundle exec rspec --color --require spec_helper --format=progress --format=Nc ...
...

Finished in 1 minute 4.69 seconds (files took 5.44 seconds to load)
228 examples, 0 failures
terminal-notifier is only supported on Mac OS X 10.8, or higher.


/home/ubuntu/FooProject/vendor/bundle/ruby/2.2.0/gems/terminal-notifier-1.6.2/lib/terminal-notifier.rb:53:in `notify': undefined method `success?' for nil:NilClass (NoMethodError)
	from /home/ubuntu/FooProject/vendor/bundle/ruby/2.2.0/gems/rspec-nc-0.2.0/lib/nc.rb:47:in `say'
	from /home/ubuntu/FooProject/vendor/bundle/ruby/2.2.0/gems/rspec-nc-0.2.0/lib/nc.rb:37:in `dump_summary'
	from /home/ubuntu/.rvm/gems/ruby-2.2.0@global/gems/rspec-core-3.2.1/lib/rspec/core/reporter.rb:146:in `block in notify'
	from /home/ubuntu/.rvm/gems/ruby-2.2.0@global/gems/rspec-core-3.2.1/lib/rspec/core/reporter.rb:145:in `each'
	from /home/ubuntu/.rvm/gems/ruby-2.2.0@global/gems/rspec-core-3.2.1/lib/rspec/core/reporter.rb:145:in `notify'
	from /home/ubuntu/.rvm/gems/ruby-2.2.0@global/gems/rspec-core-3.2.1/lib/rspec/core/reporter.rb:130:in `finish'
	from /home/ubuntu/.rvm/gems/ruby-2.2.0@global/gems/rspec-core-3.2.1/lib/rspec/core/reporter.rb:64:in `report'
	from /home/ubuntu/.rvm/gems/ruby-2.2.0@global/gems/rspec-core-3.2.1/lib/rspec/core/runner.rb:108:in `run_specs'
	from /home/ubuntu/.rvm/gems/ruby-2.2.0@global/gems/rspec-core-3.2.1/lib/rspec/core/runner.rb:86:in `run'
	from /home/ubuntu/.rvm/gems/ruby-2.2.0@global/gems/rspec-core-3.2.1/lib/rspec/core/runner.rb:70:in `run'
	from /home/ubuntu/.rvm/gems/ruby-2.2.0@global/gems/rspec-core-3.2.1/lib/rspec/core/runner.rb:38:in `invoke'
	from /home/ubuntu/.rvm/gems/ruby-2.2.0@global/gems/rspec-core-3.2.1/exe/rspec:4:in `<top (required)>'
	from /home/ubuntu/FooProject/vendor/bundle/ruby/2.2.0/bin/rspec:23:in `load'
```